### PR TITLE
fix Config @default_options synatx error

### DIFF
--- a/lib/omnigollum.rb
+++ b/lib/omnigollum.rb
@@ -136,7 +136,7 @@ module Omnigollum
       :path_templates => "#{dir}/templates",
       :default_name   => nil,
       :default_email  => nil,
-      :provider_names => []
+      :provider_names => [],
       :authorized_users => []
     }
       


### PR DESCRIPTION
Hey, I got an error running omnigollum. It seems the @default-options in Config class is missing a comma. Hope this helps.

Error details:

/usr/local/rvm/gems/ruby-2.0.0-p247/gems/gollum-2.4.13/lib/gollum.rb:20: warning: already initialized constant Gollum::VERSION
/usr/local/rvm/gems/ruby-2.0.0-p247/gems/gollum-lib-1.0.0/lib/gollum-lib.rb:32: warning: previous definition of VERSION was here
/srv/www/rack/documentation.wiki/config.ru:8:in `require': /usr/local/rvm/gems/ruby-2.0.0-p247/bundler/gems/omnigollum-4bebf90d322d/lib/omnigollum.rb:140: syntax error, unexpected tSYMBEG, expecting '}' (SyntaxError)
      :authorized_users => []
       ^
/usr/local/rvm/gems/ruby-2.0.0-p247/bundler/gems/omnigollum-4bebf90d322d/lib/omnigollum.rb:141: syntax error, unexpected '}', expecting keyword_end
    from /srv/www/rack/documentation.wiki/config.ru:8:in`block in <main>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:55:in`initialize'
    from /srv/www/rack/documentation.wiki/config.ru:in `new'
    from /srv/www/rack/documentation.wiki/config.ru:in`<main>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:49:in`new_from_string'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:277:in`build_app_and_options_from_config'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:314:in`wrapped_app'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:141:in`start'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/rackup:23:in`load'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/rackup:23:in `<main>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in`eval'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `<main>'
